### PR TITLE
added town map functionality by robbing code from field specials

### DIFF
--- a/include/item_use.h
+++ b/include/item_use.h
@@ -41,6 +41,7 @@ void ItemUseOutOfBattle_CannotUse(u8);
 void ItemUseOutOfBattle_Flash(u8);
 void ItemUseOutOfBattle_Fly(u8);
 void ItemUseOutOfBattle_ExpShare(u8);
+void ItemUseOutOfBattle_TownMap(u8);
 void ItemUseInBattle_BagMenu(u8 taskId);
 void ItemUseInBattle_PartyMenu(u8 taskId);
 void ItemUseInBattle_PartyMenuChooseMove(u8 taskId);

--- a/src/data/items.h
+++ b/src/data/items.h
@@ -11057,7 +11057,7 @@ const struct Item gItemsInfo[] =
         .importance = 1,
         .pocket = POCKET_KEY_ITEMS,
         .type = ITEM_USE_BAG_MENU,
-        .fieldUseFunc = ItemUseOutOfBattle_CannotUse,
+        .fieldUseFunc = ItemUseOutOfBattle_TownMap,
     },
 
     [ITEM_VS_SEEKER] =

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -17,6 +17,7 @@
 #include "field_effect.h"
 #include "field_player_avatar.h"
 #include "field_screen_effect.h"
+#include "field_specials.h"
 #include "field_weather.h"
 #include "fldeff.h"
 #include "item.h"
@@ -1675,5 +1676,12 @@ void ItemUseOutOfBattle_Pokevial(u8 taskId)
         PokevialPrintNoDosesMessage(isPlayerUsingRegisteredKeyItem, taskId);
 }
 //End Pokevial Branch
+
+void FieldShowRegionMap(void);
+
+void ItemUseOutOfBattle_TownMap(u8 taskId)
+{
+    FieldShowRegionMap();
+}
 
 #undef tUsingRegisteredKeyItem


### PR DESCRIPTION
- should re-add town map functionality
- just calls into the same function that is used to display the map in the pokecenter
- seems to work, probably should be careful for any weird side effects or bugs from this slightly altered use case / repurposing