### PR TITLE
I'm applying changes from rh-hideout/pokeemerald-expansion#6839.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ O_LEVEL ?= g
 else
 O_LEVEL ?= 2
 endif
-CPPFLAGS := $(INCLUDE_CPP_ARGS) -Wno-trigraphs -DMODERN=1 -DTESTING=$(TEST)
+CPPFLAGS := $(INCLUDE_CPP_ARGS) -Wno-trigraphs -DMODERN=1 -DTESTING=$(TEST) -std=gnu17
 ARMCC := $(PREFIX)gcc
 PATH_ARMCC := PATH="$(PATH)" $(ARMCC)
 CC1 := $(shell $(PATH_ARMCC) --print-prog-name=cc1) -quiet


### PR DESCRIPTION
This change updates the Makefile to use the -std=gnu17 compiler flag. This corresponds to the second patch in the referenced PR, as the first and third patches cancel each other out.

